### PR TITLE
Update timeFormat function,Supports the string "2025-06-25".

### DIFF
--- a/web/src/utils/common.ts
+++ b/web/src/utils/common.ts
@@ -320,7 +320,7 @@ export const arrayFullUrl = (relativeUrls: string | string[], domain = '') => {
 export const timeFormat = (dateTime: string | number | null = null, fmt = 'yyyy-mm-dd hh:MM:ss') => {
     if (dateTime == 'none') return i18n.global.t('None')
     if (!dateTime) dateTime = Number(new Date())
-    if (dateTime.toString().length === 10) {
+    if (dateTime.toString().length === 10 && /^\d+$/.test(dateTime.toString())) {
         dateTime = +dateTime * 1000
     }
 


### PR DESCRIPTION
当数据库字段类型为date时，检索时需要用日期空间，所以目前需要使用：
`render: 'datetime', timeFormat: 'yyyy-mm-dd', comSearchRender: 'date',`
更新前：
因为timeFormat方法的存在，导致无法正确处理 "2025-06-25" 的数据。

更新后：
可以正确显示和查询 对原有业务逻辑业务不会产生影响。